### PR TITLE
Move error on login screen

### DIFF
--- a/src/frontend/src/views/LoginView.vue
+++ b/src/frontend/src/views/LoginView.vue
@@ -7,6 +7,9 @@
             {{ newTeam ? 'Opret nyt hold' : 'Log på eksisterende hold' }}
           </h2>
         </div>
+        <div v-if="auth.loginError" class="text-red-500 text-center text-sm mt-2">
+          {{ auth.loginErrorMessage }}
+        </div>
         <form
           v-if="!newTeam"
           class="mt-8 space-y-6"
@@ -118,9 +121,6 @@
             {{ newTeam ? 'Annuller oprettelse' : 'Opret nyt hold' }}
           </button>
         </div>
-      </div>
-      <div v-if="auth.loginError" class="text-red-500 text-sm mt-2">
-        {{ auth.loginErrorMessage }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fejlbeskeden flyttes på login siden, så den ikke havner ved siden af formularen

Før:
![image](https://github.com/MatiasGadeberg/fiske-spillet/assets/16537374/72bbc861-784c-489b-b6c3-4d4ab9155465)

Efter:
![image](https://github.com/MatiasGadeberg/fiske-spillet/assets/16537374/9c59a21e-57db-49df-b505-072fbbbadad3)
